### PR TITLE
Bugfix/block-rpcbind-when-not-needed

### DIFF
--- a/defaults/main/packages.yml
+++ b/defaults/main/packages.yml
@@ -2,18 +2,15 @@
 system_upgrade: true
 packages_blocklist:
   - apport*
-# This package is required for freeipa-server on Fedora.
-#   - autofs
-# These packages are required for freeipa-server on Fedora.
-#   - avahi*
-#   - avahi-*
+  - autofs
+  - avahi*
+  - avahi-*
   - beep
   - git
   - pastebinit
   - popularity-contest
   - prelink
-# This package is required for freeipa-server on Fedora.
-#  - rpcbind
+  - rpcbind
   - rsh*
   - rsync
   - talk*


### PR DESCRIPTION
This reverts commit 1e49a20be196b62ce837e06da610fa3d6b75334a.

Reverting commit because we should block those packages by default and if we need an exception, that should be done in the packer build.

`rpcbind` should only be installed if needed. Otherwise should be removed.