### PR TITLE
Ignore a non-zero return code when `auditd.service` is restarted

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,22 @@
   ansible.builtin.command: service auditd restart
   register: service_auditd_restart
   changed_when: service_auditd_restart.rc == 0
+  failed_when:
+    - service_auditd_restart.rc != 0
+    # auditd.service depends on audit-rules.service.  The latter runs
+    # augenrules, which returns a non-zero value because some rules in
+    # templates/etc/audit/rules.d/hardening.rules.j2 mention files
+    # that do not exist.  This means that the restart of
+    # auditd.service returns a non-zero code because one of its
+    # dependencies "fails".
+    #
+    # We don't want this handler to fail because of this non-zero
+    # return code, particularly since
+    # templates/etc/audit/rules.d/hardening.rules.j2 contains a -c
+    # which means all audit rules are processed.  The only thing to do
+    # is to ignore the non-zero return code from the auditd.service
+    # restart.
+    - service_auditd_restart.rc != 1
   when: ansible_os_family == "RedHat"
   tags:
     - CCE-80872-5


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to ignore a non-zero return code when `auditd.service` is restarted.

## 💭 Motivation and context ##

`auditd.service` depends on `audit-rules.service`.  The latter runs [`augenrules`](https://man7.org/linux/man-pages/man8/augenrules.8.html), which returns a non-zero value because some rules in [`templates/etc/audit/rules.d/hardening.rules.j2`](https://github.com/cisagov/ansible-role-hardening-2/blob/master/templates/etc/audit/rules.d/hardening.rules.j2) mention files that do not exist.  This means that the restart of `auditd.service` returns a non-zero code because one of its dependencies "fails".

We don't want this handler to fail because of this non-zero return code, particularly since
[`templates/etc/audit/rules.d/hardening.rules.j2`](https://github.com/cisagov/ansible-role-hardening-2/blob/master/templates/etc/audit/rules.d/hardening.rules.j2) contains a `-c` line which means all `auditd` rules are processed anyway.  The only thing to do is to ignore the non-zero return code from the `auditd.service` restart.

## 🧪 Testing ##

I used these changes to successfully build a staging FreeIPA AMI in cisagov/freeipa-server-packer#129.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).